### PR TITLE
fix linux samples being slideshows

### DIFF
--- a/samples/flixel/source/Main.hx
+++ b/samples/flixel/source/Main.hx
@@ -40,6 +40,10 @@ class Main extends Sprite
 
 		final refreshRate:Int = Lib.application.window.displayMode.refreshRate;
 
+		#if linux
+		refreshRate = 60;
+		#end
+
 		addChild(new FlxGame(1280, 720, PlayState, refreshRate, refreshRate));
 
 		FlxG.stage.frameRate = refreshRate;

--- a/samples/flixel/source/Main.hx
+++ b/samples/flixel/source/Main.hx
@@ -38,7 +38,7 @@ class Main extends Sprite
 
 		Lib.current.loaderInfo.uncaughtErrorEvents.addEventListener(UncaughtErrorEvent.UNCAUGHT_ERROR, onUncaughtError);
 
-		final refreshRate:Int = Lib.application.window.displayMode.refreshRate;
+		var refreshRate:Int = Lib.application.window.displayMode.refreshRate;
 
 		#if linux
 		refreshRate = 60;

--- a/samples/openfl/source/Main.hx
+++ b/samples/openfl/source/Main.hx
@@ -46,6 +46,10 @@ class Main extends Sprite
 
 		Lib.current.stage.frameRate = Lib.application.window.displayMode.refreshRate;
 
+		#if linux
+		Lib.current.stage.frameRate = 60;
+		#end
+
 		#if mobile
 		copyFiles();
 		#end


### PR DESCRIPTION
`Lib.application.window.displayMode.refreshRate` doesn't like linux for some reason and sets the framerate to like 1 or something really low.