### PR TITLE
Use onVolumeChange on newer Flixel versions

### DIFF
--- a/source/hxvlc/flixel/FlxVideo.hx
+++ b/source/hxvlc/flixel/FlxVideo.hx
@@ -71,7 +71,13 @@ class FlxVideo extends Video
 
 			#if FLX_SOUND_SYSTEM
 			if (autoVolumeHandle)
+			{
+				#if (flixel >= "5.9.0")
+				FlxG.sound.onVolumeChange.add(onVolumeChange);
+				#else
 				volume = Math.floor(FlxMath.bound(getCalculatedVolume(), 0, 1) * Define.getFloat('HXVLC_FLIXEL_VOLUME_MULTIPLIER', 100));
+				#end
+			}
 			#end
 		});
 	}
@@ -166,6 +172,10 @@ class FlxVideo extends Video
 		if (FlxG.signals.focusLost.has(pause))
 			FlxG.signals.focusLost.remove(pause);
 
+		#if (FLX_SOUND_SYSTEM && flixel >= "5.9.0")
+		FlxG.sound.onVolumeChange.remove(onVolumeChange);
+		#end
+
 		super.dispose();
 	}
 
@@ -178,12 +188,20 @@ class FlxVideo extends Video
 			height = autoResizeMode.y ? FlxG.scaleMode.gameSize.y : bitmapData.height;
 		}
 
-		#if FLX_SOUND_SYSTEM
+		#if (FLX_SOUND_SYSTEM && flixel < "5.9.0")
 		if (autoVolumeHandle)
 			volume = Math.floor(FlxMath.bound(getCalculatedVolume(), 0, 1) * Define.getFloat('HXVLC_FLIXEL_VOLUME_MULTIPLIER', 100));
 		#end
 
 		super.update(deltaTime);
 	}
+
+	#if (FLX_SOUND_SYSTEM && flixel >= "5.9.0")
+	@:noCompletion
+	private function onVolumeChange(volume:Float):Void
+	{
+		volume = Math.floor(FlxMath.bound(getCalculatedVolume(), 0, 1) * Define.getFloat('HXVLC_FLIXEL_VOLUME_MULTIPLIER', 100));
+	}
+	#end
 }
 #end

--- a/source/hxvlc/flixel/FlxVideoSprite.hx
+++ b/source/hxvlc/flixel/FlxVideoSprite.hx
@@ -83,7 +83,13 @@ class FlxVideoSprite extends FlxSprite
 
 				#if FLX_SOUND_SYSTEM
 				if (autoVolumeHandle)
+				{
+					#if (flixel >= "5.9.0")
+					FlxG.sound.onVolumeChange.add(onVolumeChange);
+					#else
 					bitmap.volume = Math.floor(FlxMath.bound(getCalculatedVolume(), 0, 1) * Define.getFloat('HXVLC_FLIXEL_VOLUME_MULTIPLIER', 100));
+					#end
+				}
 				#end
 			}
 		});
@@ -265,6 +271,10 @@ class FlxVideoSprite extends FlxSprite
 		if (FlxG.signals.focusLost.has(pause))
 			FlxG.signals.focusLost.remove(pause);
 
+		#if (FLX_SOUND_SYSTEM && flixel >= "5.9.0")
+		FlxG.sound.onVolumeChange.remove(onVolumeChange);
+		#end
+
 		super.destroy();
 
 		if (bitmap != null)
@@ -293,12 +303,21 @@ class FlxVideoSprite extends FlxSprite
 
 	public override function update(elapsed:Float):Void
 	{
-		#if FLX_SOUND_SYSTEM
+		#if (FLX_SOUND_SYSTEM && flixel < "5.9.0")
 		if (bitmap != null && autoVolumeHandle)
+		{
 			bitmap.volume = Math.floor(FlxMath.bound(getCalculatedVolume(), 0, 1) * Define.getFloat('HXVLC_FLIXEL_VOLUME_MULTIPLIER', 100));
+		}
 		#end
 
 		super.update(elapsed);
+	}
+
+	@:noCompletion
+	private function onVolumeChange(volume:Float):Void
+	{
+		if (bitmap != null)
+			bitmap.volume = Math.floor(FlxMath.bound(getCalculatedVolume(), 0, 1) * Define.getFloat('HXVLC_FLIXEL_VOLUME_MULTIPLIER', 100));
 	}
 
 	@:noCompletion

--- a/source/hxvlc/flixel/FlxVideoSprite.hx
+++ b/source/hxvlc/flixel/FlxVideoSprite.hx
@@ -313,12 +313,14 @@ class FlxVideoSprite extends FlxSprite
 		super.update(elapsed);
 	}
 
+	#if (FLX_SOUND_SYSTEM && flixel >= "5.9.0")
 	@:noCompletion
 	private function onVolumeChange(volume:Float):Void
 	{
 		if (bitmap != null)
 			bitmap.volume = Math.floor(FlxMath.bound(getCalculatedVolume(), 0, 1) * Define.getFloat('HXVLC_FLIXEL_VOLUME_MULTIPLIER', 100));
 	}
+	#end
 
 	@:noCompletion
 	private override function set_antialiasing(value:Bool):Bool


### PR DESCRIPTION
Flixel 5.9.0 introduces an [`onVolumeChange` signal](https://github.com/HaxeFlixel/flixel/pull/3148) that gets dispatched whenever the global volume is changed. This PR takes advantage of this signal to update the video volume instead of constantly updating it in the update functions.