### PR TITLE
Instead of Float convert it to Std.Int

### DIFF
--- a/source/hxvlc/flixel/FlxVideoSprite.hx
+++ b/source/hxvlc/flixel/FlxVideoSprite.hx
@@ -29,7 +29,7 @@ using StringTools;
  * 	{
  * 		final scale:Float = Math.min(FlxG.width / video.bitmap.bitmapData.width, FlxG.height / video.bitmap.bitmapData.height);
  *
- * 		video.setGraphicSize(video.bitmap.bitmapData.width * scale, video.bitmap.bitmapData.height * scale);
+ * 		video.setGraphicSize(Std.int(video.bitmap.bitmapData.width * scale), Std.int(video.bitmap.bitmapData.height * scale));
  * 		video.updateHitbox();
  * 		video.screenCenter();
  * 	}


### PR DESCRIPTION
I used the example before and i come up with this
![image](https://github.com/user-attachments/assets/cf540303-9155-4922-9dcb-f66ec20bb649)
then i had to convert it using Std.int and it works
im not sure if that's a me issue.