### PR TITLE
Replace conditional block with a ternary in FlxInternalVideo

### DIFF
--- a/source/hxvlc/flixel/FlxInternalVideo.hx
+++ b/source/hxvlc/flixel/FlxInternalVideo.hx
@@ -130,10 +130,7 @@ class FlxInternalVideo extends Video
 		{
 			final normalizedPath:String = Path.normalize(str);
 
-			if (!normalizedPath.startsWith('/'))
-				return 'file:///$normalizedPath';
-			else
-				return 'file://$normalizedPath';
+			return (!normalizedPath.startsWith('/') ? 'file:///$normalizedPath' : 'file://$normalizedPath');
 		}
 
 		if (!Video.URL_VERIFICATION_REGEX.match(location))


### PR DESCRIPTION
I'm experiencing this really weird bug where, without this functionally identical change in code, I get this error when trying to build via the VSCode debugger:

![image](https://github.com/user-attachments/assets/fa6cd7c5-fa31-47cb-988b-1e713d0b16fa)

I can't reproduce this bug through any other means, even building in the terminal with identical flags, so IDK what actually caused the issue, but this solved it.