### PR TITLE
Some basic Haxe 5 compatibility

### DIFF
--- a/source/hxvlc/openfl/Video.hx
+++ b/source/hxvlc/openfl/Video.hx
@@ -16,7 +16,6 @@ import cpp.VoidStarConstStar;
 import cpp.vm.Gc;
 
 import haxe.Int64;
-import haxe.MainLoop;
 import haxe.io.Bytes;
 import haxe.io.BytesData;
 import haxe.io.BytesInput;
@@ -25,6 +24,7 @@ import hxvlc.externs.LibVLC;
 import hxvlc.externs.Types;
 import hxvlc.openfl.textures.VideoTexture;
 import hxvlc.util.Handle;
+import hxvlc.util.MainLoop;
 import hxvlc.util.Stats;
 import hxvlc.util.TrackDescription;
 import hxvlc.util.Util;

--- a/source/hxvlc/util/Handle.hx
+++ b/source/hxvlc/util/Handle.hx
@@ -4,11 +4,11 @@ import cpp.ConstCharStar;
 import cpp.Pointer;
 import cpp.StdVector;
 
-import haxe.MainLoop;
 import haxe.io.Path;
 
 import hxvlc.externs.LibVLC;
 import hxvlc.externs.Types;
+import hxvlc.util.MainLoop;
 import hxvlc.util.macros.DefineMacro;
 
 import sys.FileSystem;

--- a/source/hxvlc/util/MainLoop.hx
+++ b/source/hxvlc/util/MainLoop.hx
@@ -1,0 +1,24 @@
+package hxvlc.util;
+
+#if haxe5
+import haxe.EventLoop;
+
+/**
+ * Wrapper for compatibility with Haxe 5.
+ */
+@:forwardStatics
+abstract MainLoop(haxe.MainLoop)
+{
+  public static inline function runInMainThread(f:Void -> Void)
+  {
+    EventLoop.main.run(f);
+  }
+
+  public static inline function addThread(f:Void -> Void)
+  {
+    EventLoop.addTask(f);
+  }
+}
+#else
+typedef MainLoop = haxe.MainLoop;
+#end


### PR DESCRIPTION
Simply fixes some compile errors since they made `MainLoop` deprecated.