### PR TITLE
Remove 3 useless imports from the `FlxInternalVideo` class

### DIFF
--- a/source/hxvlc/flixel/FlxInternalVideo.hx
+++ b/source/hxvlc/flixel/FlxInternalVideo.hx
@@ -4,7 +4,6 @@ package hxvlc.flixel;
 import flixel.FlxG;
 
 import haxe.io.Bytes;
-import haxe.io.Path;
 
 using StringTools;
 

--- a/source/hxvlc/flixel/FlxInternalVideo.hx
+++ b/source/hxvlc/flixel/FlxInternalVideo.hx
@@ -6,10 +6,6 @@ import flixel.FlxG;
 import haxe.io.Bytes;
 import haxe.io.Path;
 
-import openfl.utils.Assets;
-
-import sys.FileSystem;
-
 using StringTools;
 
 /** A wrapper class for displaying video files in HaxeFlixel using the `Video` class. */


### PR DESCRIPTION
Follow-up to https://github.com/MAJigsaw77/hxvlc/commit/762596c10cda509d77ee8bf8f99ff7292b64081f