### PR TITLE
Remove 3 useless imports from the `FlxInternalVideo` class

### DIFF
--- a/source/hxvlc/flixel/FlxInternalVideo.hx
+++ b/source/hxvlc/flixel/FlxInternalVideo.hx
@@ -4,11 +4,6 @@ package hxvlc.flixel;
 import flixel.FlxG;
 
 import haxe.io.Bytes;
-import haxe.io.Path;
-
-import openfl.utils.Assets;
-
-import sys.FileSystem;
 
 using StringTools;
 


### PR DESCRIPTION
Redo https://github.com/MAJigsaw77/hxvlc/pull/103, but in one commit this time.