### PR TITLE
Adjustments for `cppia` to work with `hxvlc`

### DIFF
--- a/samples/flixel/source/VideoState.hx
+++ b/samples/flixel/source/VideoState.hx
@@ -19,7 +19,6 @@ class VideoState extends FlxState
 	{
 		FlxG.autoPause = false;
 
-
 		video = new FlxVideoSprite(0, 0);
 
 		video.bitmap.onEndReached.add(function():Void

--- a/source/hxvlc/impl/Finalizeable.hx
+++ b/source/hxvlc/impl/Finalizeable.hx
@@ -22,7 +22,9 @@ class Finalizeable
 	{
 		this.owned = owned;
 
+		#if !cppia
 		Gc.setFinalizer(this, Function.fromStaticFunction(finalize));
+		#end
 	}
 
 	/**
@@ -32,6 +34,7 @@ class Finalizeable
 	 */
 	public function destroy():Void {}
 
+	#if !cppia
 	@:noCompletion
 	@:noDebug
 	@:unreflective
@@ -40,4 +43,5 @@ class Finalizeable
 		if (finalizeable.owned)
 			finalizeable.destroy();
 	}
+	#end
 }

--- a/source/hxvlc/impl/Instance.hx
+++ b/source/hxvlc/impl/Instance.hx
@@ -19,15 +19,6 @@ import hxvlc.impl.externs.LibVLC;
 import sys.thread.Mutex;
 
 /** Represents a implementation or wrapper for the native LibVLC instance */
-@:cppInclude('stdarg.h')
-@:cppNamespaceCode('static int vsnprintf_safe(char* buffer, size_t size, const char* fmt, va_list args)
-{
-    va_list copy;
-    va_copy(copy, args);
-    int len = vsnprintf(buffer, size, fmt, copy);
-    va_end(copy);
-    return len;
-}')
 class Instance extends Finalizeable
 {
 	#if (windows || macos)
@@ -158,7 +149,7 @@ class Instance extends Finalizeable
 		{
 			onLog = cb;
 
-			LibVLC.log_set(nativeInstance, Function.fromStaticFunction(logCallback), untyped __cpp__('this'));
+			LibVLC.log_set(nativeInstance, Function.fromStaticFunction(InstanceCallbacks.logCallback), untyped __cpp__('this'));
 		}
 		else if (onLog != null)
 		{
@@ -196,11 +187,25 @@ class Instance extends Finalizeable
 	{
 		return LibVLC.get_changeset();
 	}
+}
 
+@:access(hxvlc.impl.Instance)
+@:cppInclude('stdarg.h')
+@:cppNamespaceCode('static int vsnprintf_safe(char* buffer, size_t size, const char* fmt, va_list args)
+{
+    va_list copy;
+    va_copy(copy, args);
+    int len = vsnprintf(buffer, size, fmt, copy);
+    va_end(copy);
+    return len;
+}')
+@:unreflective
+private class InstanceCallbacks
+{
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	static function logCallback(data:RawPointer<cpp.Void>, level:Int, ctx:RawConstPointer<LibVLC_Log_T>, fmt:ConstCharStar, args:VarList):Void
+	public static function logCallback(data:RawPointer<cpp.Void>, level:Int, ctx:RawConstPointer<LibVLC_Log_T>, fmt:ConstCharStar, args:VarList):Void
 	{
 		final instance:Instance = untyped __cpp__('reinterpret_cast<Instance_obj *>({0})', data);
 
@@ -223,7 +228,7 @@ class Instance extends Finalizeable
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	public static function getStringFromFormat(fmt:ConstCharStar, args:VarList):String
+	private static function getStringFromFormat(fmt:ConstCharStar, args:VarList):String
 	{
 		final len:Int = untyped vsnprintf_safe(untyped nullptr, 0, fmt, args);
 
@@ -258,7 +263,7 @@ class Instance extends Finalizeable
 
 		if (normalizedPath.length > 0)
 		{
-			for (logPath in POSSIBLE_LIBVLC_LOG_PATHS)
+			for (logPath in Instance.POSSIBLE_LIBVLC_LOG_PATHS)
 			{
 				final index:Int = normalizedPath.indexOf(logPath, 0);
 

--- a/source/hxvlc/impl/Media.hx
+++ b/source/hxvlc/impl/Media.hx
@@ -72,12 +72,14 @@ class Media extends Finalizeable
 		if (bytes == null || bytes.length == 0)
 			return null;
 
+		final input:RawPointer<Input> = untyped __cpp__('new Input({0})', bytes);
+
 		final media:Media = new Media();
 
 		@:nullSafety(Off)
-		media.nativeMedia = LibVLC.media_new_callbacks(instance.nativeInstance, Function.fromStaticFunction(mediaOpen),
-			Function.fromStaticFunction(mediaRead), Function.fromStaticFunction(mediaSeek), Function.fromStaticFunction(mediaClose),
-			untyped __cpp__('new Input({0})', bytes));
+		media.nativeMedia = LibVLC.media_new_callbacks(instance.nativeInstance, Function.fromStaticFunction(MediaCallbacks.mediaOpen),
+			Function.fromStaticFunction(MediaCallbacks.mediaRead), Function.fromStaticFunction(MediaCallbacks.mediaSeek),
+			Function.fromStaticFunction(MediaCallbacks.mediaClose), untyped input);
 
 		return media;
 	}
@@ -239,11 +241,16 @@ class Media extends Finalizeable
 
 		return null;
 	}
+}
 
+@:access(hxvlc.impl.Media)
+@:unreflective
+private class MediaCallbacks
+{
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function mediaOpen(opaque:RawPointer<cpp.Void>, datap:RawPointer<RawPointer<cpp.Void>>, sizep:RawPointer<UInt64>):Int
+	public static function mediaOpen(opaque:RawPointer<cpp.Void>, datap:RawPointer<RawPointer<cpp.Void>>, sizep:RawPointer<UInt64>):Int
 	{
 		final input:RawPointer<Input> = untyped __cpp__('reinterpret_cast<Input *>({0})', opaque);
 
@@ -268,7 +275,7 @@ class Media extends Finalizeable
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function mediaRead(opaque:RawPointer<cpp.Void>, buf:RawPointer<UInt8>, len:SizeT):SSizeT
+	public static function mediaRead(opaque:RawPointer<cpp.Void>, buf:RawPointer<UInt8>, len:SizeT):SSizeT
 	{
 		final input:RawPointer<Input> = untyped __cpp__('reinterpret_cast<Input *>({0})', opaque);
 
@@ -291,7 +298,7 @@ class Media extends Finalizeable
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function mediaSeek(opaque:RawPointer<cpp.Void>, offset:UInt64):Int
+	public static function mediaSeek(opaque:RawPointer<cpp.Void>, offset:UInt64):Int
 	{
 		final input:RawPointer<Input> = untyped __cpp__('reinterpret_cast<Input *>({0})', opaque);
 
@@ -314,7 +321,7 @@ class Media extends Finalizeable
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function mediaClose(opaque:RawPointer<cpp.Void>):Void
+	public static function mediaClose(opaque:RawPointer<cpp.Void>):Void
 	{
 		var input:RawPointer<Input> = untyped __cpp__('reinterpret_cast<Input *>({0})', opaque);
 

--- a/source/hxvlc/impl/events/MediaEvents.hx
+++ b/source/hxvlc/impl/events/MediaEvents.hx
@@ -48,19 +48,28 @@ class MediaEvents
 
 		if (eventManager != null)
 		{
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaParsedChanged, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaMetaChanged, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaSubItemAdded, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaDurationChanged, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaSubItemTreeAdded, Function.fromStaticFunction(eventManagerCallbacks),
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaParsedChanged, Function.fromStaticFunction(MediaEventsCallbacks.eventManagerCallbacks),
+				untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaMetaChanged, Function.fromStaticFunction(MediaEventsCallbacks.eventManagerCallbacks),
+				untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaSubItemAdded, Function.fromStaticFunction(MediaEventsCallbacks.eventManagerCallbacks),
+				untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaDurationChanged, Function.fromStaticFunction(MediaEventsCallbacks.eventManagerCallbacks),
+				untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaSubItemTreeAdded, Function.fromStaticFunction(MediaEventsCallbacks.eventManagerCallbacks),
 				untyped __cpp__('this'));
 		}
 	}
+}
 
+@:access(hxvlc.impl.events.MediaEvents)
+@:unreflective
+private class MediaEventsCallbacks
+{
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function eventManagerCallbacks(p_event:RawConstPointer<LibVLC_Event_T>, p_data:RawPointer<cpp.Void>):Void
+	public static function eventManagerCallbacks(p_event:RawConstPointer<LibVLC_Event_T>, p_data:RawPointer<cpp.Void>):Void
 	{
 		final mediaEvents:MediaEvents = untyped __cpp__('reinterpret_cast<MediaEvents_obj *>({0})', p_data);
 

--- a/source/hxvlc/impl/events/MediaPlayerEvents.hx
+++ b/source/hxvlc/impl/events/MediaPlayerEvents.hx
@@ -78,35 +78,48 @@ class MediaPlayerEvents
 
 		if (eventManager != null)
 		{
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerOpening, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerPlaying, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerStopped, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerPaused, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerEndReached, Function.fromStaticFunction(eventManagerCallbacks),
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerOpening,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerPlaying,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerStopped,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerPaused, Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks),
 				untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerEncounteredError, Function.fromStaticFunction(eventManagerCallbacks),
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerEndReached,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerEncounteredError,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerCorked, Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks),
 				untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerCorked, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerUncorked, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerESAdded, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerESDeleted, Function.fromStaticFunction(eventManagerCallbacks), untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerESSelected, Function.fromStaticFunction(eventManagerCallbacks),
-				untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerTimeChanged, Function.fromStaticFunction(eventManagerCallbacks),
-				untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerPositionChanged, Function.fromStaticFunction(eventManagerCallbacks),
-				untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerLengthChanged, Function.fromStaticFunction(eventManagerCallbacks),
-				untyped __cpp__('this'));
-			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerMediaChanged, Function.fromStaticFunction(eventManagerCallbacks),
-				untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerUncorked,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerESAdded,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerESDeleted,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerESSelected,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerTimeChanged,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerPositionChanged,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerLengthChanged,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
+			LibVLC.event_attach(eventManager, untyped libvlc_MediaPlayerMediaChanged,
+				Function.fromStaticFunction(MediaPlayerEventsCallbacks.eventManagerCallbacks), untyped __cpp__('this'));
 		}
 	}
+}
 
+@:access(hxvlc.impl.events.MediaPlayerEvents)
+@:unreflective
+private class MediaPlayerEventsCallbacks
+{
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function eventManagerCallbacks(p_event:RawConstPointer<LibVLC_Event_T>, p_data:RawPointer<cpp.Void>):Void
+	public static function eventManagerCallbacks(p_event:RawConstPointer<LibVLC_Event_T>, p_data:RawPointer<cpp.Void>):Void
 	{
 		final mediaPlayerEvents:MediaPlayerEvents = untyped __cpp__('reinterpret_cast<MediaPlayerEvents_obj *>({0})', p_data);
 

--- a/source/hxvlc/impl/output/AudioOutput.hx
+++ b/source/hxvlc/impl/output/AudioOutput.hx
@@ -63,20 +63,26 @@ class AudioOutput
 
 		this.mutex = new Mutex();
 
-		LibVLC.audio_set_callbacks(mediaPlayer.nativeMediaPlayer, Function.fromStaticFunction(audioPlay), Function.fromStaticFunction(audioPause),
-			Function.fromStaticFunction(audioResume), Function.fromStaticFunction(audioFlush), Function.fromStaticFunction(audioDrain),
+		LibVLC.audio_set_callbacks(mediaPlayer.nativeMediaPlayer, Function.fromStaticFunction(AudioOutputCallbacks.audioPlay),
+			Function.fromStaticFunction(AudioOutputCallbacks.audioPause), Function.fromStaticFunction(AudioOutputCallbacks.audioResume),
+			Function.fromStaticFunction(AudioOutputCallbacks.audioFlush), Function.fromStaticFunction(AudioOutputCallbacks.audioDrain),
 			untyped __cpp__('this'));
 
-		LibVLC.audio_set_volume_callback(mediaPlayer.nativeMediaPlayer, Function.fromStaticFunction(audioSetVolume));
+		LibVLC.audio_set_volume_callback(mediaPlayer.nativeMediaPlayer, Function.fromStaticFunction(AudioOutputCallbacks.audioSetVolume));
 
 		@:nullSafety(Off)
-		LibVLC.audio_set_format_callbacks(mediaPlayer.nativeMediaPlayer, Function.fromStaticFunction(audioFormatSetup), null);
+		LibVLC.audio_set_format_callbacks(mediaPlayer.nativeMediaPlayer, Function.fromStaticFunction(AudioOutputCallbacks.audioFormatSetup), null);
 	}
+}
 
+@:access(hxvlc.impl.output.AudioOutput)
+@:unreflective
+private class AudioOutputCallbacks
+{
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function audioPlay(data:RawPointer<cpp.Void>, samples:RawConstPointer<cpp.Void>, count:UInt32, pts:Int64):Void
+	public static function audioPlay(data:RawPointer<cpp.Void>, samples:RawConstPointer<cpp.Void>, count:UInt32, pts:Int64):Void
 	{
 		final audioOutput:AudioOutput = untyped __cpp__('reinterpret_cast<AudioOutput_obj *>({0})', data);
 
@@ -104,7 +110,7 @@ class AudioOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function audioPause(data:RawPointer<cpp.Void>, pts:Int64):Void
+	public static function audioPause(data:RawPointer<cpp.Void>, pts:Int64):Void
 	{
 		final audioOutput:AudioOutput = untyped __cpp__('reinterpret_cast<AudioOutput_obj *>({0})', data);
 
@@ -127,7 +133,7 @@ class AudioOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function audioResume(data:RawPointer<cpp.Void>, pts:Int64):Void
+	public static function audioResume(data:RawPointer<cpp.Void>, pts:Int64):Void
 	{
 		final audioOutput:AudioOutput = untyped __cpp__('reinterpret_cast<AudioOutput_obj *>({0})', data);
 
@@ -150,7 +156,7 @@ class AudioOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function audioFlush(data:RawPointer<cpp.Void>, pts:Int64):Void
+	public static function audioFlush(data:RawPointer<cpp.Void>, pts:Int64):Void
 	{
 		final audioOutput:AudioOutput = untyped __cpp__('reinterpret_cast<AudioOutput_obj *>({0})', data);
 
@@ -173,7 +179,7 @@ class AudioOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function audioDrain(data:RawPointer<cpp.Void>):Void
+	public static function audioDrain(data:RawPointer<cpp.Void>):Void
 	{
 		final audioOutput:AudioOutput = untyped __cpp__('reinterpret_cast<AudioOutput_obj *>({0})', data);
 
@@ -196,7 +202,7 @@ class AudioOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function audioSetVolume(data:RawPointer<cpp.Void>, volume:Single, mute:Bool):Void
+	public static function audioSetVolume(data:RawPointer<cpp.Void>, volume:Single, mute:Bool):Void
 	{
 		// Empty because the way LibVLC handles the audio volume's isnt really nice,
 		// and this callback cant be removed as if removed,
@@ -206,7 +212,7 @@ class AudioOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function audioFormatSetup(opaque:RawPointer<RawPointer<cpp.Void>>, format:CastCharStar, rate:RawPointer<UInt32>,
+	public static function audioFormatSetup(opaque:RawPointer<RawPointer<cpp.Void>>, format:CastCharStar, rate:RawPointer<UInt32>,
 			channels:RawPointer<UInt32>):Int
 	{
 		final audioOutput:AudioOutput = untyped __cpp__('reinterpret_cast<AudioOutput_obj *>(*{0})', opaque);

--- a/source/hxvlc/impl/output/VideoOutput.hx
+++ b/source/hxvlc/impl/output/VideoOutput.hx
@@ -73,17 +73,23 @@ class VideoOutput
 		this.bytesPerPixel = bytesPerPixel;
 		this.nativeMediaPlayer = mediaPlayer.nativeMediaPlayer;
 
-		LibVLC.video_set_callbacks(nativeMediaPlayer, Function.fromStaticFunction(videoLock), Function.fromStaticFunction(videoUnlock),
-			Function.fromStaticFunction(videoDisplay), untyped __cpp__('this'));
+		LibVLC.video_set_callbacks(nativeMediaPlayer, Function.fromStaticFunction(VideoOutputCallbacks.videoLock),
+			Function.fromStaticFunction(VideoOutputCallbacks.videoUnlock), Function.fromStaticFunction(VideoOutputCallbacks.videoDisplay),
+			untyped __cpp__('this'));
 
 		@:nullSafety(Off)
-		LibVLC.video_set_format_callbacks(nativeMediaPlayer, Function.fromStaticFunction(videoFormatSetup), null);
+		LibVLC.video_set_format_callbacks(nativeMediaPlayer, Function.fromStaticFunction(VideoOutputCallbacks.videoFormatSetup), null);
 	}
+}
 
+@:access(hxvlc.impl.output.VideoOutput)
+@:unreflective
+private class VideoOutputCallbacks
+{
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function videoLock(data:RawPointer<cpp.Void>, p_pixels:RawPointer<RawPointer<cpp.Void>>):cpp.RawPointer<cpp.Void>
+	public static function videoLock(data:RawPointer<cpp.Void>, p_pixels:RawPointer<RawPointer<cpp.Void>>):cpp.RawPointer<cpp.Void>
 	{
 		final videoOutput:VideoOutput = untyped __cpp__('reinterpret_cast<VideoOutput_obj *>({0})', data);
 
@@ -108,7 +114,7 @@ class VideoOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function videoUnlock(data:RawPointer<cpp.Void>, id:RawPointer<cpp.Void>, p_pixels:VoidStarConstStar):Void
+	public static function videoUnlock(data:RawPointer<cpp.Void>, id:RawPointer<cpp.Void>, p_pixels:VoidStarConstStar):Void
 	{
 		final videoOutput:VideoOutput = untyped __cpp__('reinterpret_cast<VideoOutput_obj *>({0})', data);
 
@@ -127,7 +133,7 @@ class VideoOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function videoDisplay(opaque:RawPointer<cpp.Void>, picture:RawPointer<cpp.Void>):Void
+	public static function videoDisplay(opaque:RawPointer<cpp.Void>, picture:RawPointer<cpp.Void>):Void
 	{
 		final videoOutput:VideoOutput = untyped __cpp__('reinterpret_cast<VideoOutput_obj *>({0})', opaque);
 
@@ -151,8 +157,8 @@ class VideoOutput
 	@:noDebug
 	@:nullSafety(Off)
 	@:unreflective
-	private static function videoFormatSetup(opaque:RawPointer<RawPointer<cpp.Void>>, chroma:CastCharStar, width:RawPointer<UInt32>,
-			height:RawPointer<UInt32>, pitches:RawPointer<UInt32>, lines:RawPointer<UInt32>):UInt32
+	public static function videoFormatSetup(opaque:RawPointer<RawPointer<cpp.Void>>, chroma:CastCharStar, width:RawPointer<UInt32>, height:RawPointer<UInt32>,
+			pitches:RawPointer<UInt32>, lines:RawPointer<UInt32>):UInt32
 	{
 		final videoOutput:VideoOutput = untyped __cpp__('reinterpret_cast<VideoOutput_obj *>(*{0})', opaque);
 
@@ -213,7 +219,7 @@ class VideoOutput
 	@:noCompletion
 	@:noDebug
 	@:unreflective
-	private static function calculateVideoSize(mediaPlayer:RawPointer<LibVLC_Media_Player_T>, width:RawPointer<UInt32>, height:RawPointer<UInt32>):Bool
+	public static function calculateVideoSize(mediaPlayer:RawPointer<LibVLC_Media_Player_T>, width:RawPointer<UInt32>, height:RawPointer<UInt32>):Bool
 	{
 		if (mediaPlayer != null)
 		{


### PR DESCRIPTION
Removes finalizer call from a class that should never be scripted regardless (or called from one)

Moves callbacks around so they're able to be compiled with CPPIA (in instance and media)

This allows CPPIA to be compiled in HXVLC